### PR TITLE
Resolve insufficient amount data problem

### DIFF
--- a/bayesian_cnn_prometheus/preprocessing/preprocessing_pipeline.py
+++ b/bayesian_cnn_prometheus/preprocessing/preprocessing_pipeline.py
@@ -32,19 +32,22 @@ class PreprocessingPipeline:
 
         def generator():
             steps = [TransformNiftiToNpy(self.config), NormalizeImages(self.config), CreateChunks(self.config)]
-            for image_index in self.dataset_structure[dataset_type]:
-                x_npy, y_npy = steps[0].run(self.config, image_index)
-                x_npy_norm = steps[1].run(self.config, x_npy)
-                images_chunks, targets_chunks = [], []
-                for x_chunk, y_chunk in zip(steps[2].run(self.config, x_npy_norm), steps[2].run(self.config, y_npy)):
-                    x_chunk = x_chunk.reshape((*x_chunk.shape, 1))
-                    y_chunk = y_chunk.reshape((*y_chunk.shape, 1))
 
-                    images_chunks.append(x_chunk)
-                    targets_chunks.append(y_chunk)
+            while True:
+                for image_index in self.dataset_structure[dataset_type]:
+                    x_npy, y_npy = steps[0].run(self.config, image_index)
+                    x_npy_norm = steps[1].run(self.config, x_npy)
+                    images_chunks, targets_chunks = [], []
+                    for x_chunk, y_chunk in zip(steps[2].run(self.config, x_npy_norm),
+                                                steps[2].run(self.config, y_npy)):
+                        x_chunk = x_chunk.reshape((*x_chunk.shape, 1))
+                        y_chunk = y_chunk.reshape((*y_chunk.shape, 1))
 
-                    if len(images_chunks) == batch_size and len(targets_chunks) == batch_size:
-                        yield np.array(images_chunks), np.array(targets_chunks)
+                        images_chunks.append(x_chunk)
+                        targets_chunks.append(y_chunk)
+
+                        if len(images_chunks) == batch_size and len(targets_chunks) == batch_size:
+                            yield np.array(images_chunks), np.array(targets_chunks)
 
         return generator
 

--- a/main.py
+++ b/main.py
@@ -1,6 +1,4 @@
-from preprocessing_pipeline.main import main as run_pipeline
 import os
 
-run_pipeline()
-os.system("cd network && sbatch ../run_python_script.sh train.py")
+os.system('sbatch run_python_script.sh bayesian_cnn_prometheus/learning/train_network.py')
 


### PR DESCRIPTION
Przy próbie treningu na niewystarczającej ilości danych (np epochs = 15, batch_size = 16) uczenie było przerywane błędem "KeyError", który (wbrew pozorom) wynika z tego, że brakuje danych walidacyjnych. Jako tymczasowe rozwiązanie dodaję pętlę while True na generatorze, żeby po zakończeniu "nextów" na zadanym datasecie generował batche od nowa (czyli takie, jakie już brały udział w treningu/walidacji). 
Rozwiązanie nie jest eleganckie, ale działa. Nad jego ulepszeniem możemy myśleć w miedzyczasie lub zostawić aż repo będzie działac od początku do końca. :) 